### PR TITLE
Renamed ViewLayout to TreeLayout which better describes what it does

### DIFF
--- a/lib/motion-kit-cocoa/layouts/cagradientlayer_layout.rb
+++ b/lib/motion-kit-cocoa/layouts/cagradientlayer_layout.rb
@@ -1,6 +1,6 @@
 # @provides MotionKit::CAGradientLayerLayout
 # @requires MotionKit::CALayerLayout
-# @requires MotionKit::ViewLayout
+# @requires MotionKit::TreeLayout
 module MotionKit
   class CAGradientLayerLayout < CALayerLayout
     targets CAGradientLayer

--- a/lib/motion-kit-cocoa/layouts/calayer_layout.rb
+++ b/lib/motion-kit-cocoa/layouts/calayer_layout.rb
@@ -1,7 +1,7 @@
 # @provides MotionKit::CALayerLayout
-# @requires MotionKit::ViewLayout
+# @requires MotionKit::TreeLayout
 module MotionKit
-  class CALayerLayout < ViewLayout
+  class CALayerLayout < TreeLayout
     targets CALayer
 
     # platform specific default root view

--- a/lib/motion-kit-ios/layouts/uiview_layout.rb
+++ b/lib/motion-kit-ios/layouts/uiview_layout.rb
@@ -1,8 +1,8 @@
 # @provides MotionKit::Layout
 # @provides MotionKit::UIViewLayout
-# @requires MotionKit::ViewLayout
+# @requires MotionKit::TreeLayout
 module MotionKit
-  class Layout < ViewLayout
+  class Layout < TreeLayout
 
     # platform specific default root view
     def default_root

--- a/lib/motion-kit-osx/layouts/nsmenu_layout.rb
+++ b/lib/motion-kit-osx/layouts/nsmenu_layout.rb
@@ -1,8 +1,8 @@
 # @provides MotionKit::MenuLayout
 # @provides MotionKit::NSMenuLayout
-# @requires MotionKit::ViewLayout
+# @requires MotionKit::TreeLayout
 module MotionKit
-  class MenuLayout < ViewLayout
+  class MenuLayout < TreeLayout
 
     # A more sensible name for the menu that is created.
     def menu

--- a/lib/motion-kit-osx/layouts/nsview_layout.rb
+++ b/lib/motion-kit-osx/layouts/nsview_layout.rb
@@ -1,8 +1,8 @@
 # @provides MotionKit::Layout
 # @provides MotionKit::NSViewLayout
-# @requires MotionKit::ViewLayout
+# @requires MotionKit::TreeLayout
 module MotionKit
-  class Layout < ViewLayout
+  class Layout < TreeLayout
 
     # platform specific default root view
     def default_root

--- a/lib/motion-kit-osx/layouts/nswindow_layout.rb
+++ b/lib/motion-kit-osx/layouts/nswindow_layout.rb
@@ -1,8 +1,8 @@
 # @provides MotionKit::WindowLayout
 # @provides MotionKit::NSWindowLayout
-# @requires MotionKit::ViewLayout
+# @requires MotionKit::TreeLayout
 module MotionKit
-  class WindowLayout < ViewLayout
+  class WindowLayout < TreeLayout
 
     # A more sensible name for the window that is created.
     def window

--- a/lib/motion-kit/layouts/base_layout.rb
+++ b/lib/motion-kit/layouts/base_layout.rb
@@ -8,7 +8,7 @@ module MotionKit
   # delegated to the 'apply' method, which accepts a method name, arguments, and
   # an optional block to set the new context.
   #
-  # The ViewLayout subclass defines methods that are appropriate for adding and
+  # The TreeLayout subclass defines methods that are appropriate for adding and
   # removing views to a view hierarchy.
   class BaseLayout
     # Class methods reside in base_layout_class_methods.rb

--- a/lib/motion-kit/layouts/tree_layout.rb
+++ b/lib/motion-kit/layouts/tree_layout.rb
@@ -1,14 +1,12 @@
-# @provides MotionKit::ViewLayout
+# @provides MotionKit::TreeLayout
 # @requires MotionKit::BaseLayout
 module MotionKit
-  # A sensible parent class for any View-like layout class. Platform agnostic.
-  # Any platform-specific tasks are offloaded to child views (add_child,
-  # remove_child).
-  # Actually, "view like" is misleading, since technically it only assumes "tree
-  # like". You could use a ViewLayout subclass to construct a hierarchy
+  # A sensible parent class for any Tree-like layout class. Platform agnostic.
+  # Any platform-specific tasks are offloaded to child elements (add_child,
+  # remove_child). You could use a TreeLayout subclass to construct a hierarchy
   # representing a family tree, for instance. But that would be a silly use of
   # MotionKit.
-  class ViewLayout < BaseLayout
+  class TreeLayout < BaseLayout
 
     class << self
 
@@ -278,7 +276,7 @@ module MotionKit
         if @assign_root
           create_default_root_context
         else
-          NSLog('Warning! No root view was set in ViewLayout#layout. Did you mean to call `root`?')
+          NSLog('Warning! No root view was set in TreeLayout#layout. Did you mean to call `root`?')
         end
       end
       run_deferred(@view)
@@ -311,11 +309,11 @@ module MotionKit
     # Accepts a view instance, a class (which is instantiated with 'new') or a
     # `ViewLayout`, which returns the root view.
     def initialize_view(elem)
-      if elem.is_a?(Class) && elem < ViewLayout
+      if elem.is_a?(Class) && elem < TreeLayout
         elem = elem.new_child(@layout, nil, self).view
       elsif elem.is_a?(Class)
         elem = elem.new
-      elsif elem.is_a?(ViewLayout)
+      elsif elem.is_a?(TreeLayout)
         elem = elem.view
       end
 


### PR DESCRIPTION
Previously, the heirarchy was `UIViewLayout < Layout < ViewLayout` which didn't make a ton of sense. This renames `ViewLayout` to `TreeLayout` since that more properly describes what it's doing.

```
559 specifications (2675 requirements), 0 failures, 0 errors
```
