### PR TITLE
Fix option A: use 'MotionKit.color_class'

### DIFF
--- a/lib/motion-kit-cocoa/layouts/cagradientlayer_layout.rb
+++ b/lib/motion-kit-cocoa/layouts/cagradientlayer_layout.rb
@@ -6,7 +6,7 @@ module MotionKit
     targets CAGradientLayer
 
     def colors(values)
-      target.colors = values.map { |color| color.is_a?(UIColor) ? color.CGColor : color }
+      target.colors = values.map { |color| color.is_a?(MotionKit.color_class) ? color.CGColor : color }
     end
 
   end

--- a/lib/motion-kit-ios/ios_util.rb
+++ b/lib/motion-kit-ios/ios_util.rb
@@ -13,6 +13,10 @@ module MotionKit
     UIView
   end
 
+  def color_class
+    UIColor
+  end
+
   def no_intrinsic_metric
     UIViewNoIntrinsicMetric
   end

--- a/lib/motion-kit-osx/osx_util.rb
+++ b/lib/motion-kit-osx/osx_util.rb
@@ -9,6 +9,10 @@ module MotionKit
     NSView
   end
 
+  def color_class
+    NSColor
+  end
+
   def no_intrinsic_metric
     NSViewNoInstrinsicMetric
   end


### PR DESCRIPTION
The `CAGradientLayerLayout` methods are in the `cocoa/` folder, and so it is supposed to work on ios _AND_ osx, but the color class in there prevents it.

Here's one way to fix it, and [here](https://github.com/rubymotion/motion-kit/issues/19) is another.
