### PR TITLE
Added build and built? methods, updated README

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,9 +288,11 @@ You can also pass in a root view to your layout, like this:
 
 ```ruby
 def loadView
-  @layout = MyLayout.new(root: self.view)
+  @layout = MyLayout.new(root: self.view).build
 end
 ```
+
+Make sure to call `.build`; otherwise, the layout will be returned but the view not built.
 
 In this case, if you want to style the root view, just refer to it in your layout:
 
@@ -307,7 +309,6 @@ end
 ```
 
 This is especially useful with collection views, table views, and table cells.
-
 
 ### How do styles get applied?
 

--- a/app/ios/spec/test_custom_root_layout.rb
+++ b/app/ios/spec/test_custom_root_layout.rb
@@ -48,7 +48,7 @@ class TestNestedView < UIView
 
   def init
     super
-    @layout = TestNestedLayout.new(root: self)
+    @layout = TestNestedLayout.new(root: self).build
     self
   end
 

--- a/app/osx/spec/test_custom_root_layout.rb
+++ b/app/osx/spec/test_custom_root_layout.rb
@@ -48,7 +48,7 @@ class TestNestedView < NSView
 
   def init
     super
-    @layout = TestNestedLayout.new(root: self)
+    @layout = TestNestedLayout.new(root: self).build
     self
   end
 

--- a/lib/motion-kit/layouts/base_layout.rb
+++ b/lib/motion-kit/layouts/base_layout.rb
@@ -24,10 +24,7 @@ module MotionKit
       @layout_delegate = nil
       @layout_state = :initial
       # You can set a root view by using .new(root: some_view)
-      if args[:root]
-        @preset_root = args[:root]
-        view # Prebuild the view
-      end
+      @preset_root = args[:root]
     end
 
     def set_layout(layout)

--- a/lib/motion-kit/layouts/tree_layout.rb
+++ b/lib/motion-kit/layouts/tree_layout.rb
@@ -56,6 +56,18 @@ module MotionKit
       @view ||= build_view
     end
 
+    # Builds the layout and then returns self for chaining.
+    def build
+      view
+      self
+    end
+
+    # Checks if the layout has been built yet or not.
+    def built?
+      !@view.nil?
+    end
+    alias build? built? # just in case
+
     # Assign a view to act as the 'root' view for this layout.  This method can
     # only be called once, and must be called before `add` is called for the
     # first time (otherwise `add` will create a default root view).  This method

--- a/spec/ios/custom_root_layout_spec.rb
+++ b/spec/ios/custom_root_layout_spec.rb
@@ -33,4 +33,18 @@ describe MotionKit::Layout do
     @subject.view.subviews.first.subviews.first.backgroundColor.should == UIColor.blackColor
   end
 
+  it "shouldn't build if `build` or `view` aren't called" do
+    @subject.built?.should == false
+  end
+
+  it "should build when `build` is called" do
+    @subject.build
+    @subject.built?.should == true
+  end
+
+  it "should build when `view` is called" do
+    @subject.view
+    @subject.built?.should == true
+  end
+
 end


### PR DESCRIPTION
``` ruby
@layout = MyLayout.new(root: self.view)
@layout.built? # => false
@layout.build # this
@layout.view # ...or this
@layout.built? # => true
```

The difference between `.view` and `.build` is that `.view` returns the root view while `.build` returns the layout instance.
