### PR TITLE
Including the MotionKit gem causes MyClass#id to return nil

### DIFF
--- a/lib/motion-kit-cocoa/constraints/constraint.rb
+++ b/lib/motion-kit-cocoa/constraints/constraint.rb
@@ -239,7 +239,6 @@ module MotionKit
       self
     end
     alias identified_by identifier
-    alias id identifier
 
     def update_constraint
       if @resolved


### PR DESCRIPTION
I was going crazy for a while, and I still don't know exactly what's happening. I only know that I managed to find the code that's causing me grief:

For whatever reason, one line of code, [alias id identifier](https://github.com/rubymotion/motion-kit/blob/master/lib/motion-kit-cocoa/constraints/constraint.rb#L242), is causing all of my classes to return `nil` for the attribute `id`.

Is this actually a bug in RubyMotion? I'm so confused...
### How to Replicate
1. Grab the [Motion-Tickspot](https://github.com/codelation/motion-tickspot) source code.
2. Run `rake spec`: Everything passes.
3. Add `gem "motion-kit"` to the Gemfile
4. Run `rake spec`: All tests that use object.id fail.
