### PR TITLE
Refactored constraints_layout.rb to reduce duplicated code.

### DIFF
--- a/lib/motion-kit-cocoa/constraints/constraints_layout.rb
+++ b/lib/motion-kit-cocoa/constraints/constraints_layout.rb
@@ -18,485 +18,184 @@ module MotionKit
     end
 
     def x(value=nil)
-      constraint = Constraint.new(target.view, :left, :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:left, :equal, value)
     end
     alias left x
 
     def min_x(value=nil)
-      constraint = Constraint.new(target.view, :left, :gte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:left, :gte, value)
     end
     alias min_left min_x
 
     def max_x(value=nil)
-      constraint = Constraint.new(target.view, :left, :lte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:left, :lte, value)
     end
     alias max_left max_x
 
     def leading(value=nil)
-      constraint = Constraint.new(target.view, :leading, :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:leading, :equal, value)
     end
 
     def min_leading(value=nil)
-      constraint = Constraint.new(target.view, :leading, :gte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:leading, :gte, value)
     end
 
     def max_leading(value=nil)
-      constraint = Constraint.new(target.view, :leading, :lte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:leading, :lte, value)
     end
 
     def center_x(value=nil)
-      constraint = Constraint.new(target.view, :center_x, :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:center_x, :equal, value)
     end
 
     def min_center_x(value=nil)
-      constraint = Constraint.new(target.view, :center_x, :gte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:center_x, :gte, value)
     end
 
     def max_center_x(value=nil)
-      constraint = Constraint.new(target.view, :center_x, :lte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:center_x, :lte, value)
     end
 
     def right(value=nil)
-      constraint = Constraint.new(target.view, :right, :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:right, :equal, value)
     end
 
     def min_right(value=nil)
-      constraint = Constraint.new(target.view, :right, :gte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:right, :gte, value)
     end
 
     def max_right(value=nil)
-      constraint = Constraint.new(target.view, :right, :lte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:right, :lte, value)
     end
 
     def trailing(value=nil)
-      constraint = Constraint.new(target.view, :trailing, :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:trailing, :equal, value)
     end
 
     def min_trailing(value=nil)
-      constraint = Constraint.new(target.view, :trailing, :gte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:trailing, :gte, value)
     end
 
     def max_trailing(value=nil)
-      constraint = Constraint.new(target.view, :trailing, :lte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:trailing, :lte, value)
     end
 
     def y(value=nil)
-      constraint = Constraint.new(target.view, :top, :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:top, :equal, value)
     end
     alias top y
 
     def min_y(value=nil)
-      constraint = Constraint.new(target.view, :top, :gte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:top, :gte, value)
     end
     alias min_top min_y
 
     def max_y(value=nil)
-      constraint = Constraint.new(target.view, :top, :lte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:top, :lte, value)
     end
     alias max_top max_y
 
     def center_y(value=nil)
-      constraint = Constraint.new(target.view, :center_y, :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:center_y, :equal, value)
     end
 
     def min_center_y(value=nil)
-      constraint = Constraint.new(target.view, :center_y, :gte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:center_y, :gte, value)
     end
 
     def max_center_y(value=nil)
-      constraint = Constraint.new(target.view, :center_y, :lte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:center_y, :lte, value)
     end
 
     def bottom(value=nil)
-      constraint = Constraint.new(target.view, :bottom, :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:bottom, :equal, value)
     end
 
     def min_bottom(value=nil)
-      constraint = Constraint.new(target.view, :bottom, :gte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:bottom, :gte, value)
     end
 
     def max_bottom(value=nil)
-      constraint = Constraint.new(target.view, :bottom, :lte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:bottom, :lte, value)
     end
 
     def baseline(value=nil)
-      constraint = Constraint.new(target.view, :baseline, :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:baseline, :equal, value)
     end
 
     def min_baseline(value=nil)
-      constraint = Constraint.new(target.view, :baseline, :gte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:baseline, :gte, value)
     end
 
     def max_baseline(value=nil)
-      constraint = Constraint.new(target.view, :baseline, :lte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:baseline, :lte, value)
     end
 
     def width(value=nil)
-      constraint = Constraint.new(target.view, :width, :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:width, :equal, value)
     end
     alias w width
 
     def min_width(value=nil)
-      constraint = Constraint.new(target.view, :width, :gte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:width, :gte, value)
     end
 
     def max_width(value=nil)
-      constraint = Constraint.new(target.view, :width, :lte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:width, :lte, value)
     end
 
     def height(value=nil)
-      constraint = Constraint.new(target.view, :height, :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:height, :equal, value)
     end
     alias h height
 
     def min_height(value=nil)
-      constraint = Constraint.new(target.view, :height, :gte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:height, :gte, value)
     end
 
     def max_height(value=nil)
-      constraint = Constraint.new(target.view, :height, :lte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:height, :lte, value)
     end
 
     def size(value=nil)
-      constraint = SizeConstraint.new(target.view, :size, :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:size, :equal, value, SizeConstraint)
     end
 
     def min_size(value=nil)
-      constraint = SizeConstraint.new(target.view, :size, :gte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:size, :gte, value, SizeConstraint)
     end
 
     def max_size(value=nil)
-      constraint = SizeConstraint.new(target.view, :size, :lte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint(:size, :lte, value, SizeConstraint)
     end
 
     def center(value=nil)
-      constraint = PointConstraint.new(target.view, [:center_x, :center_y], :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint([:center_x, :center_y], :equal, value, PointConstraint)
     end
 
     def min_center(value=nil)
-      constraint = PointConstraint.new(target.view, [:center_x, :center_y], :gte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint([:center_x, :center_y], :gte, value, PointConstraint)
     end
 
     def max_center(value=nil)
-      constraint = PointConstraint.new(target.view, [:center_x, :center_y], :lte)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint([:center_x, :center_y], :lte, value, PointConstraint)
     end
 
     def top_left(value=nil)
-      constraint = PointConstraint.new(target.view, [:left, :top], :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint([:left, :top], :equal, value, PointConstraint)
     end
     alias origin top_left
 
     def top_right(value=nil)
-      constraint = PointConstraint.new(target.view, [:right, :top], :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint([:right, :top], :equal, value, PointConstraint)
     end
 
     def bottom_left(value=nil)
-      constraint = PointConstraint.new(target.view, [:left, :bottom], :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint([:left, :bottom], :equal, value, PointConstraint)
     end
 
     def bottom_right(value=nil)
-      constraint = PointConstraint.new(target.view, [:right, :bottom], :equal)
-
-      if value
-        constraint.equals(value)
-      end
-
-      target.add_constraints([constraint])
-      return constraint
+      target_constraint([:right, :bottom], :equal, value, PointConstraint)
     end
 
     def above(view)
@@ -532,6 +231,16 @@ module MotionKit
       return constraint
     end
     alias right_of after
+
+  private
+
+    def target_constraint(attribute, relationship, value=nil, constraint_class=nil)
+      constraint_class ||= Constraint
+      constraint = constraint_class.new(target.view, attribute, relationship)
+      constraint.equals(value) if value
+      target.add_constraints([constraint])
+      constraint
+    end
 
   end
 end


### PR DESCRIPTION
I created a single method that works for most of the constraints. `above`, `below`, `before`, `after` are somewhat different so I didn't refactor those. They could probably be moved into another common method as well, but probably not worth it.

Removed 291 lines of code with no loss of functionality.
