### PR TITLE
support overriding styles of an existing column

### DIFF
--- a/lib/motion-kit-osx/layouts/nstableview_layout.rb
+++ b/lib/motion-kit-osx/layouts/nstableview_layout.rb
@@ -16,5 +16,16 @@ module MotionKit
     end
     alias add_table_column add_column
 
+    def column(column_or_identifier, &block)
+      if column_or_identifier.is_a?(NSTableColumn)
+        column = column_or_identifier
+      else
+        column_index = target.columnWithIdentifier(column_or_identifier)
+        column = target.tableColumns[column_index]
+      end
+      context(column, &block)
+    end
+    alias table_column column
+
   end
 end


### PR DESCRIPTION
use case: style existing columns that have previously been added programmatically.

``` ruby
def table_view_style
  column('name') do
    width 150
  end
end
```
