### PR TITLE
Allow multiple args to view attr method

### DIFF
--- a/app/ios/spec/test_view_attr_layout.rb
+++ b/app/ios/spec/test_view_attr_layout.rb
@@ -1,10 +1,13 @@
 class TestViewAttrLayout < MK::Layout
   view :button
   view :label
+  view :text_field, :text_view
 
   def layout
     add UIButton, :button
     add UILabel, :label
+    add UITextField, :text_field
+    add UITextView, :text_view
   end
 
 end

--- a/lib/motion-kit/layouts/tree_layout.rb
+++ b/lib/motion-kit/layouts/tree_layout.rb
@@ -28,22 +28,31 @@ module MotionKit
       #       end
       #
       #     end
-      def view(name)
-        ivar_name = "@#{name}"
-        define_method(name) do
-          unless instance_variable_get(ivar_name)
-            view = self.get_view(name)
-            unless view
-              build_view unless @view
-              view = instance_variable_get(ivar_name) || self.get_view(name)
+      #
+      # You can also set multiple views in a single line.
+      #
+      # @example
+      #     class MyLayout < MK::Layout
+      #       view :label, :login_button
+      #     end
+      def view(*names)
+        names.each do |name|
+          ivar_name = "@#{name}"
+          define_method(name) do
+            unless instance_variable_get(ivar_name)
+              view = self.get_view(name)
+              unless view
+                build_view unless @view
+                view = instance_variable_get(ivar_name) || self.get_view(name)
+              end
+              self.send("#{name}=", view)
+              return view
             end
-            self.send("#{name}=", view)
-            return view
+            return instance_variable_get(ivar_name)
           end
-          return instance_variable_get(ivar_name)
+          # KVO compliance
+          attr_writer name
         end
-        # KVO compliance
-        attr_writer name
       end
 
     end

--- a/spec/ios/view_attr_spec.rb
+++ b/spec/ios/view_attr_spec.rb
@@ -22,4 +22,11 @@ describe 'View attr' do
     label.should == @layout.label
   end
 
+  it 'should handle multiple views' do
+    @layout.view
+    text_field = @layout.text_field
+    text_field.should.be.kind_of(UITextField)
+    text_view = @layout.text_view
+    text_view.should.be.kind_of(UITextView)
+  end
 end


### PR DESCRIPTION
This will allow `view` to accept multiple names similar to `attr_accessor`, etc., so you can do `view :button, :label` instead of having to do one view per line (useful when you have 10-15 views in a layout).
