### PR TITLE
updates readme to describe "prev" instead of "prevous"

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,10 +717,10 @@ One common use case is to use a child layout to create many instances of the
 same layout that repeat, for instance a "row" of content.  In this case you will
 probably have many views with the same id, and you will not know the index of
 the container view that you want to add constraints to.  In this situation, use
-the `nearest`, `previous` or `next` method to find a container, sibling, or
+the `nearest`, `prev` or `next` method to find a container, sibling, or
 child view.
 
-`previous` and `next` are easy; they just search for a sibling view.  No
+`prev` and `next` are easy; they just search for a sibling view.  No
 superviews or subviews are searched.
 
 `nearest` will search child views, siblings, and superviews, in that order.  The


### PR DESCRIPTION
I'd have preferred to add an alias here, and make "previous" work, but I'm not sure how to alias the objective-C'ish signature.