### PR TITLE
Clarify method name in TreeLayout#initial warning

### DIFF
--- a/lib/motion-kit/helpers/tree_layout.rb
+++ b/lib/motion-kit/helpers/tree_layout.rb
@@ -197,7 +197,7 @@ module MotionKit
 
     def initial(&block)
       raise ArgumentError.new('Block required') unless block
-      puts('this method is no longer necessary!  all code that *isn\'t in a `reapply` block is now only applied during initial setup.')
+      puts('the `initial` method is no longer necessary!  all code that *isn\'t in a `reapply` block is now only applied during initial setup.')
 
       if initial?
         yield


### PR DESCRIPTION
```ruby
puts('this method is no longer necessary!  all code that *isn\'t in a `reapply` block is now only applied during initial setup.')
```

Because this is just output and not an exception being raised, RubyMotion doesn't show any hint (e.g. a backtrace) of what's generating this message.

I had to grep my bundled gems to figure out where this message was being triggered, and only then was I able to see it was from still having an `initial` block.

Let's help the user out a little! :smile: 