### PR TITLE
OS X spec fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ script:
     - bundle install
     - bundle exec rake clean
     - bundle exec rake spec
+    - bundle exec rake spec platform=osx

--- a/app/osx/spec/test_custom_root_layout.rb
+++ b/app/osx/spec/test_custom_root_layout.rb
@@ -67,3 +67,16 @@ class TestMultipleNestedLayout < MotionKit::Layout
   end
 
 end
+
+class TestNoRootLayout < MotionKit::Layout
+
+  def layout
+    background_color NSColor.redColor
+    add NSTextField, :purple_view
+  end
+
+  def purple_view_style
+    background_color NSColor.purpleColor
+  end
+
+end

--- a/lib/motion-kit-osx/helpers/nsview_autoresizing_helpers.rb
+++ b/lib/motion-kit-osx/helpers/nsview_autoresizing_helpers.rb
@@ -39,7 +39,7 @@ module MotionKit
         when :fill_bottom
           value |= NSViewWidthSizable | NSViewMaxYMargin
         when :fill_width
-          value |= NSViewMinYMargin | NSViewWidthSizable | NSViewMaxXMargin
+          value |= NSViewMinYMargin | NSViewWidthSizable | NSViewMaxYMargin
         when :fill_left
           value |= NSViewHeightSizable | NSViewMaxXMargin
         when :fill_right

--- a/spec/osx/custom_root_layout_spec.rb
+++ b/spec/osx/custom_root_layout_spec.rb
@@ -50,8 +50,8 @@ describe 'Custom Root Layouts' do
   it "should allow bare styles in layout when root is specified in initializer" do
     @subject = TestNoRootLayout.new(root: @view).build
     @subject.view.should == @view
-    @subject.view.backgroundColor.should == UIColor.redColor
-    @subject.view.subviews.first.should.be.kind_of?(UILabel)
+    @subject.view.backgroundColor.should == NSColor.redColor
+    @subject.view.subviews.first.should.be.kind_of?(NSTextField)
   end
 
 end


### PR DESCRIPTION
Hey, I noticed that the OS X specs weren't passing, and weren't included in the TravisCI build either. I added them in, and then fixed up the couple of issues stopping it from having an entirely green test suite across the board. If there was a reason OS X was excluded then feel free to revert the .travis.yml change!