### PR TITLE
NSTabView add_tab helper

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,4 @@ script:
     - bundle install
     - bundle exec rake clean
     - bundle exec rake spec
+    - bundle exec rake spec platform=osx

--- a/app/osx/spec/test_custom_root_layout.rb
+++ b/app/osx/spec/test_custom_root_layout.rb
@@ -67,3 +67,16 @@ class TestMultipleNestedLayout < MotionKit::Layout
   end
 
 end
+
+class TestNoRootLayout < MotionKit::Layout
+
+  def layout
+    background_color NSColor.redColor
+    add NSTextField, :purple_view
+  end
+
+  def purple_view_style
+    background_color NSColor.purpleColor
+  end
+
+end

--- a/lib/motion-kit-osx/helpers/nstabview_helpers.rb
+++ b/lib/motion-kit-osx/helpers/nstabview_helpers.rb
@@ -1,0 +1,11 @@
+class NSTabViewHelpers < MK::NSViewHelpers
+  targets NSTabView
+
+  def add_tab(identifier, label, &block)
+    tab_view_item = NSTabViewItem.alloc.initWithIdentifier(identifier)
+    tab_view_item.label = label
+    target.addTabViewItem(tab_view_item)
+    tab_view_item.view = NSView.alloc.initWithFrame(target.contentRect)
+    context(tab_view_item.view, &block)
+  end
+end

--- a/lib/motion-kit-osx/helpers/nsview_autoresizing_helpers.rb
+++ b/lib/motion-kit-osx/helpers/nsview_autoresizing_helpers.rb
@@ -39,7 +39,7 @@ module MotionKit
         when :fill_bottom
           value |= NSViewWidthSizable | NSViewMaxYMargin
         when :fill_width
-          value |= NSViewMinYMargin | NSViewWidthSizable | NSViewMaxXMargin
+          value |= NSViewMinYMargin | NSViewWidthSizable | NSViewMaxYMargin
         when :fill_left
           value |= NSViewHeightSizable | NSViewMaxXMargin
         when :fill_right

--- a/spec/osx/custom_root_layout_spec.rb
+++ b/spec/osx/custom_root_layout_spec.rb
@@ -50,8 +50,8 @@ describe 'Custom Root Layouts' do
   it "should allow bare styles in layout when root is specified in initializer" do
     @subject = TestNoRootLayout.new(root: @view).build
     @subject.view.should == @view
-    @subject.view.backgroundColor.should == UIColor.redColor
-    @subject.view.subviews.first.should.be.kind_of?(UILabel)
+    @subject.view.backgroundColor.should == NSColor.redColor
+    @subject.view.subviews.first.should.be.kind_of?(NSTextField)
   end
 
 end

--- a/spec/osx/nstabview_helper_spec.rb
+++ b/spec/osx/nstabview_helper_spec.rb
@@ -1,0 +1,27 @@
+describe 'NSTabView helpers' do
+  class TestTabViewLayout < MK::Layout
+    def layout
+      add NSTabView, :tab_view do
+        add_tab "tab_identifier", "tab_label" do
+          wantsLayer true
+          backgroundColor NSColor.redColor
+        end
+      end
+    end
+  end
+
+  it 'should support `add_tab` method' do
+    @layout = TestTabViewLayout.new
+
+    view = NSView.alloc.initWithFrame([[0, 0], [500, 500]])
+    view.addSubview(@layout.view)
+
+    @tab_view = @layout.get(:tab_view)
+
+    @tab_view.numberOfTabViewItems.should == 1
+    @tab_view.tabViewItems.first.identifier.should == "tab_identifier"
+    @tab_view.tabViewItems.first.label.should == "tab_label"
+    @tab_view.tabViewItems.first.view.wantsLayer.should == true
+    @tab_view.tabViewItems.first.view.backgroundColor.should == NSColor.redColor
+  end
+end


### PR DESCRIPTION
Thought I'd add this as a separate PR to the OS X fixes, as I wasn't sure if additional control helper methods were wanted in the main gem or not...

This is a simple addition to support adding tab items nested beneath a tab view, and which then allows you to use the rest of the brilliant MotionKit DSL to setup and configure the corresponding view for a tab as you would any other view, so you can create a fairly complicated set of tabs all from within your MotionKit layout.

It came about while trying to make a section of [my book](http://kickcode.com/building-mac-os-x-apps-with-rubymotion/) a bit more concise - let me know if it's better off in (or as) a separate gem, or if it needs any tweaking though.