### PR TITLE
Use xcode7.2 for building specs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: objective-c
+osx_image: xcode7.2
 before_install:
     - (ruby --version)
     - sudo chown -R travis ~/Library/RubyMotion


### PR DESCRIPTION
According to the docs, you can set the Xcode version in travis.yml
https://docs.travis-ci.com/user/languages/objective-c/

Maybe it will make the tvOS specs green. Let's see.