### PR TITLE
All tvOS specs are now green with the latest RM

### DIFF
--- a/spec/tvos/calayer_spec.rb
+++ b/spec/tvos/calayer_spec.rb
@@ -1,6 +1,3 @@
-# TODO disabled until CGColor is fixed
-return true
-
 describe 'CALayerHelpers' do
 
   before do

--- a/spec/tvos/layer_layout_spec.rb
+++ b/spec/tvos/layer_layout_spec.rb
@@ -1,6 +1,3 @@
-# TODO disabled until CGColor is fixed
-return true
-
 describe TestLayerHelpers do
   before do
     @subject = TestLayerHelpers.new


### PR DESCRIPTION
RM 4.7 fixes the CGColor issue, so we can enable all the specs.