### PR TITLE
Bug fix to PR #135

### DIFF
--- a/lib/motion-kit/helpers/base_layout.rb
+++ b/lib/motion-kit/helpers/base_layout.rb
@@ -92,6 +92,8 @@ module MotionKit
       return new_target unless block
       # this little line is incredibly important; the context is only set on
       # the top-level Layout object.
+
+      # mp "MOTIONKIT CONTEXT is #{new_target} meta: #{new_target.motion_kit_meta}"
       return parent_layout.context(new_target, &block) unless is_parent_layout?
 
       if new_target.is_a?(Symbol)

--- a/lib/motion-kit/helpers/tree_layout.rb
+++ b/lib/motion-kit/helpers/tree_layout.rb
@@ -436,7 +436,7 @@ module MotionKit
       unless is_parent_layout?
         return parent_layout.remove_view(element_id, view)
       end
-      removed = forget_view(element_id, view)
+      removed = forget_tree(element_id, view)
       if removed
         context(self.view) do
           self.apply(:remove_child, removed)
@@ -463,13 +463,28 @@ module MotionKit
       unless is_parent_layout?
         return parent_layout.remove_view(element_id, view)
       end
+      # mp "forgetting #{element_id}, #{view}"
       removed = nil
       context(self.view) do
-        removed = @elements[element_id].delete(view)
+        removed = @elements[element_id].delete(view) if @elements[element_id]
       end
       removed
     end
 
+    # returns the root view that was removed, if any
+    def forget_tree(element_id, view)
+      removed = forget_view(element_id, view)
+      if view.subviews
+        view.subviews.each do | sub |
+          if (sub_ids = sub.motion_kit_meta[:motion_kit_ids])
+            sub_ids.each do | sub_id |
+              forget_tree(sub_id, sub) || []
+            end
+          end
+        end
+      end
+      removed
+    end
 
     def create_default_root_context
       if @assign_root


### PR DESCRIPTION
Ran into an issue where I was using all(:style_name) to operate on views and a view that had been removed via remove_view(:style_name) introduced in  #135 showed up in motion-kit's collection.  Setting context on these elements threw an exception 
```
'NoMethodError', reason: 'base_layout.rb:116:in `context:': undefined method `constraints' for nil:NilClass (NoMethodError)
```
 since the views were removed. 

Dug a little deeper and realized that I needed to remove the subviews recursively from @elements when removing a view; this is the bug fix.