### PR TITLE
Change dbt back to a runtime dependency

### DIFF
--- a/motion-kit.gemspec
+++ b/motion-kit.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |s|
     s.specification_version = 4
   end
 
-  s.add_development_dependency(%q<dbt>, [">= 1.1.5", "~> 1.1"])
+  s.add_dependency(%q<dbt>, [">= 1.1.5", "~> 1.1"])
 end


### PR DESCRIPTION
[This commit](https://github.com/motion-kit/motion-kit/commit/cf4eacd42821994766d4a448fbf3266e9d0785a0) (presumably accidentally) changes `dbt` from a standard dependency to a development dependency (which means it isn't installed when not working on this gem). This causes apps to fail to compile when they hit [this line](https://github.com/motion-kit/motion-kit/blob/master/lib/motion-kit.rb#L6) unless `dbt` has been already included as a dependency of the project.